### PR TITLE
Fix /speedrunner permission level and compass use

### DIFF
--- a/src/main/java/io/github/ytg1234/manhunt/command/SpeedrunnerCommand.java
+++ b/src/main/java/io/github/ytg1234/manhunt/command/SpeedrunnerCommand.java
@@ -15,16 +15,12 @@ import static net.minecraft.server.command.CommandManager.literal;
 
 public class SpeedrunnerCommand {
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        dispatcher.register(
-                literal("speedrunner").then(
-                            literal("set").then(
-                                argument("target", EntityArgumentType.player()).executes(SpeedrunnerCommand::executeSet)
-                                           )
-                ).then(
-                        literal("get").executes(SpeedrunnerCommand::executeGet)
-                ).then(
-                        literal("clear").executes(SpeedrunnerCommand::executeClear)
-                )
+        dispatcher.register(literal("speedrunner").requires(source -> source.hasPermissionLevel(2))
+                                                  .then(literal("set").then(argument("target",
+                                                                            EntityArgumentType.player()
+                                                                            ).executes(SpeedrunnerCommand::executeSet)))
+                                                  .then(literal("get").executes(SpeedrunnerCommand::executeGet))
+                                                  .then(literal("clear").executes(SpeedrunnerCommand::executeClear))
         );
     }
 

--- a/src/main/java/io/github/ytg1234/manhunt/mixin/CompassItemMixin.java
+++ b/src/main/java/io/github/ytg1234/manhunt/mixin/CompassItemMixin.java
@@ -31,7 +31,7 @@ public abstract class CompassItemMixin extends Item {
                     if (user.inventory.getStack(i) == null || ManhuntUtils.speedrunner == null) continue;
                     ItemStack stack = user.inventory.getStack(i);
                     if (stack.getItem().equals(Items.COMPASS)) {
-                        ManhuntUtils.updateCompass(stack, fromServer(Objects.requireNonNull(user.getServer()), ManhuntUtils.speedrunner));
+                        user.equip(i, ManhuntUtils.updateCompass(stack, fromServer(Objects.requireNonNull(user.getServer()), ManhuntUtils.speedrunner)));
                         //                        CompoundTag itemTag = stack.getTag() == null ? new CompoundTag() : stack.getTag().copy();
                         //                        itemTag.putBoolean("LodestoneTracked", false);
                         //                        itemTag.putString("LodestoneDimension", fromServer(Objects.requireNonNull(user.getServer()), ManhuntUtils.speedrunner).getServerWorld().getRegistryKey().getValue().toString());


### PR DESCRIPTION
Hello! I guess the title says all.

The /speedrunner command could be executed by everyone, so I made it have the same permission level as /hunters.
The compass would never update when using it and having the correct config, but I found out it was because the new ItemStack wasn't replacing the old one, so I made it do that.

Thanks for creating this mod! I will be using it today with friends.